### PR TITLE
Add the facebook pixel service

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -93,6 +93,14 @@ import { GoogleAnalytics } from 'cookieguard';
 new GoogleAnalytics('UA-0000000-1');
 ```
 
+### Facebook Pixel
+To integrate a Facebook Pixel, you just need to provide your *Pixel ID* and register the service. The service automatically sets the `PageView` event.
+```js
+import { FacebookPixel } from 'cookieguard';
+
+new FacebookPixel('12345600000000');
+```
+
 ## Extending cookieguard
 You can easily extend cookieguard by creating your own service providers. A service provider must provide an `enable` and a `disable` method and should extend the base `Service` class.
 

--- a/index.js
+++ b/index.js
@@ -6,3 +6,6 @@ export const Service = AbstractService;
 
 import GoogleAnalyticsService from "./src/services/GoogleAnalytics.js";
 export const GoogleAnalytics = GoogleAnalyticsService;
+
+import FacebookPixelService from "./src/services/FacebookPixel.js";
+export const FacebookPixel = FacebookPixelService;

--- a/src/services/FacebookPixel.js
+++ b/src/services/FacebookPixel.js
@@ -1,0 +1,47 @@
+import Service from "./Service.js";
+import { expireCookie } from "../helpers.js";
+
+export default class FacebookPixel extends Service {
+    constructor(id, domain, path) {
+        super(domain, path);
+
+        this.id = id;
+    }
+
+    enable() {
+        this._embedScript();
+
+        let fbq = window.fbq = function () {
+            fbq.callMethod
+                ? fbq.callMethod.apply(fbq, arguments)
+                : fbq.queue.push(arguments);
+        }
+
+        if (!window._fbq) {
+            window._fbq = fbq;
+        }
+
+        fbq.push = fbq;
+        fbq.loaded = true;
+        fbq.version = "2.0";
+        fbq.queue = [];
+
+        fbq("init", this.id)
+        fbq("track", "PageView")
+    }
+
+    disable() {
+        expireCookie("_fbp", this.cookie.domain, this.cookie.path);
+        expireCookie("_fr", this.cookie.domain, this.cookie.path);
+        expireCookie("fr", "facebook.com", "/");
+    }
+
+    _embedScript() {
+        let script = document.createElement("script");
+        script.async = true;
+        script.src = "https://connect.facebook.net/en_US/fbevents.js";
+        document
+            .getElementsByTagName("head")[0]
+            .appendChild(script, document.getElementsByTagName("head")[0]);
+    }
+}


### PR DESCRIPTION
This PR integrates a new `Service`. The `FacebookPixelService` allows enabling/disabling the Facebook Pixel at runtime.