### PR TITLE
Add the instagram embed provider

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,5 +10,8 @@ export const GoogleAnalytics = GoogleAnalyticsService;
 import FacebookPixelService from './src/services/FacebookPixel.js';
 export const FacebookPixel = FacebookPixelService;
 
+import InstagramEmbedService from './src/services/InstagramEmbed.js';
+export const InstagramEmbed = InstagramEmbedService;
+
 import YoutubeEmbedService from './src/services/YoutubeEmbed.js';
 export const YoutubeEmbed = YoutubeEmbedService;

--- a/src/services/InstagramEmbed.js
+++ b/src/services/InstagramEmbed.js
@@ -1,0 +1,25 @@
+import Service from "./Service.js";
+import { expireCookie } from "../helpers.js";
+
+export default class InstagramEmbed extends Service {
+    constructor(domain, path) {
+        super(domain, path);
+    }
+
+    enable() {
+        this._embedScript();
+
+        //
+    }
+
+    disable() {
+        //
+    }
+
+    _embedScript() {
+        let script = document.createElement("script");
+        script.async = true;
+        script.src = '//www.instagram.com/embed.js';
+        document.body.appendChild(script);
+    }
+}

--- a/src/services/InstagramEmbed.js
+++ b/src/services/InstagramEmbed.js
@@ -9,11 +9,13 @@ export default class InstagramEmbed extends Service {
     enable() {
         this._embedScript();
 
-        //
+        this.isEnabled = true;
     }
 
     disable() {
-        //
+        if (this.isEnabled) {
+            throw 'Could not disable Instagram embeds at runtime. Page refresh required.';
+        }
     }
 
     _embedScript() {


### PR DESCRIPTION
This PR adds an `InstagramEmbed` provider. 

The provider handles the cookies set by Instagram embeds and adds enhancements to the fallback.

:bowtie: